### PR TITLE
Target Android 12 preview

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,15 +34,15 @@ android {
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'androidx.core:core-ktx:1.5.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     testImplementation 'junit:junit:4.13.1'
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    androidTestImplementation 'androidx.test:runner:1.3.0'
-    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3-beta01'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0-beta01'
+    androidTestImplementation 'androidx.test:runner:1.4.0-beta01'
+    androidTestImplementation 'androidx.test:rules:1.4.0-beta01'
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion "android-S"
 
     defaultConfig {
         applicationId "io.bitrise.sample.android"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion "S"
         versionCode 1
         versionName "1.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.BitriseSample">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -58,7 +58,7 @@ workflows:
         - environment_variables: |-
             coverage=true
             coverageFile=/sdcard/coverage.ec
-        - test_devices: 'NexusLowRes,S,en,portrait'
+        - test_devices: 'NexusLowRes,30,en,portrait'
     - deploy-to-bitrise-io@1:
         inputs:
         - notify_user_groups: none

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -26,7 +26,7 @@ workflows:
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@4: {}
+    - git-clone@6: {}
     - cache-pull@2: {}
     - script@1:
         title: Do anything with Script step
@@ -58,7 +58,7 @@ workflows:
         - environment_variables: |-
             coverage=true
             coverageFile=/sdcard/coverage.ec
-        - test_devices: 'NexusLowRes,29,en,portrait'
+        - test_devices: 'NexusLowRes,S,en,portrait'
     - deploy-to-bitrise-io@1:
         inputs:
         - notify_user_groups: none
@@ -119,7 +119,7 @@ workflows:
     steps:
     - activate-ssh-key@4:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
-    - git-clone@4: {}
+    - git-clone@6: {}
     - cache-pull@2: {}
     - install-missing-android-tools@2:
         inputs:


### PR DESCRIPTION
Testing Android 12 (`android-S`), do not merge yet.

Updated `androidx.test` dependencies to a pre-release because these export an activity via the manifest that needs to be `exported=true`. Details: https://stackoverflow.com/questions/67654506/manifest-merger-failed-targeting-android-12